### PR TITLE
If Chocolatey has just been installed yet its env variable is missing…

### DIFF
--- a/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
+++ b/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
@@ -97,10 +97,10 @@ function Set-TargetResource
         $ChocoCommand = switch ($Ensure) {
             'Present' {
                 if ($testResult.PackagePresent -and !$testResult.VersionGreaterOrEqual) {
-                    Get-Command Update-ChocolateyPackage 
+                    Get-Command Update-ChocolateyPackage
                 }
                 elseif (!$UpdateOnly) {
-                    Get-Command Install-ChocolateyPackage 
+                    Get-Command Install-ChocolateyPackage
                 }
                 else {
                     Write-Verbose "Nothing to do: UpdateOnly : $UpdateOnly"
@@ -143,12 +143,12 @@ function Set-TargetResource
         &$ChocoCommand @ChocoCommandParams -verbose | Write-Verbose
 
         $PostActionResult = Test-ChocolateyPackageIsInstalled @TestParams
-        if ($PostActionResult.PackagePresent -and 
+        if ($PostActionResult.PackagePresent -and
             $PostActionResult.VersionGreaterOrEqual -and
             $Ensure -eq 'Present') {
             Write-Verbose -Message "--> Package Successfully Installed"
         }
-        elseif ((!$PostActionResult.PackagePresent -or 
+        elseif ((!$PostActionResult.PackagePresent -or
                 !$PostActionResult.VersionGreaterOrEqual) -and
                  $Ensure -eq 'Absent') {
             Write-Verbose -Message "--> Package Successfully Removed"
@@ -204,6 +204,14 @@ function Test-TargetResource
             $option -in (Get-Command Test-ChocolateyPackageIsInstalled).Parameters.keys) {
             $null = $TestParams.Add($option,$ChocoOptions[$Option])
         }
+    }
+
+    Write-Verbose "Testing whether we need to refresh the PS environment so chocolatey doesn't fail"
+    if ($null -eq $env:ChocolateyInstall) {
+        write-verbose "Set ChocolateyInstall"
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        refreshenv > $null
     }
 
     $EnsureResultMap = @{


### PR DESCRIPTION
…, force refresh PS and chocolatey environments.
This relates to an unusual problem @gaelcolas and I were discussing in January. When FIPS encryption must be set (as it will for US government installations) for Chocolatey to work, after FIPS is successfully set, and chocolatey packages are successfully pushed, a subsequent DSC push without an intervening refreshenv or reboot will fail.

But a refreshenv, with a refresh of the chocolateyprofile fixes that. @gaelcolas thought it would be bad (I agree) to call refreshEnv every time any chocolatey resource was called. I eventually narrowed down where the problem was occurring, and made a test that will only trigger the refreshenv when the DSC push is about fail for want of the refreshenv. Therefore, it doesn't waste time on unneeded refreshenv's.

Note: I added a Write-Verbose right before my code to announce what was happening. If that is too "chatty", it can certainly be removed.