### PR TITLE
fixing pipeline yaml with main config

### DIFF
--- a/.pipelines/public-azure-pipeline.yaml
+++ b/.pipelines/public-azure-pipeline.yaml
@@ -222,6 +222,8 @@ stages:
             env:
               GitHubToken: $(GitHubToken)
               GalleryApiToken: $(GalleryApiToken)
+              ReleaseBranch: main
+              MainGitBranch: main
           - task: PowerShell@2
             name: sendChangelogPR
             displayName: 'Send Changelog PR'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- modified project with new Sampler template. 
+- Modified project with new Sampler template. 
 
 ### Removed
 


### PR DESCRIPTION
Hopefully that should do it.
Repo hasn't been tagged and source haven't been updated, so no new pre-released will be published.

Best is to tag v0.2.0-preview0003 after it's merged to main, and manually kick off a build.
Gitversion will see new commits, new tag and should build/release/publish for us.