### PR TITLE
fixing chocolateyPackage to manage dependencies when using chocoOptions @{Forcedependencies = $true}

### DIFF
--- a/.pipelines/public-azure-pipeline.yaml
+++ b/.pipelines/public-azure-pipeline.yaml
@@ -73,7 +73,7 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: '-tasks hqrmtest'
-              pwsh: false
+              pwsh: true
 
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the `ChocolateyIsInstalled` Azure Automanage Machine Configuration package that validates that Chocolatey is installed.
+- Added repository's Wiki.
 
 ### Removed
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -21,6 +21,7 @@
         }
     }
 
+    PSDesiredStateConfiguration = '2.0.6'
     'Sampler.GitHubTasks'       = 'latest'
     MarkdownLinkCheck           = 'latest'
     'DscResource.Common'        = 'latest'

--- a/build.yaml
+++ b/build.yaml
@@ -46,6 +46,7 @@ BuildWorkflow:
   pack:
     - build
     - package_module_nupkg
+    - gcpol
 
   hqrmtest:
     # - Set_PSModulePath
@@ -156,7 +157,7 @@ GitHubConfig:
   GitHubFilesToAdd:
     - 'CHANGELOG.md'
   ReleaseAssets:
-    - output/GCPackages/ChocoIsInstalled*.zip
+    - output/GCPackages/ChocolateyIsInstalled*.zip
   GitHubConfigUserName: dscbot
   GitHubConfigUserEmail: dsccommunity@outlook.com
   UpdateChangelogOnPrerelease: false

--- a/source/Classes/002.ChocolateyPackage.ps1
+++ b/source/Classes/002.ChocolateyPackage.ps1
@@ -7,7 +7,7 @@ using namespace System.Management.Automation
     .DESCRIPTION
         The ChocolateyPackage DSC Resource helps with chocolatey package management.
     .PARAMETER Name
-        The exact name of the ChocolateyPackage to set in the desired state.
+        The name of the ChocolateyPackage to set in the desired state.
     .PARAMETER Version
         The version of the package to install. If not set, it will only ensure the package
         is present/absent.
@@ -241,7 +241,6 @@ class ChocolateyPackage
             'ShouldNotBeInstalled$'
             {
                 $chocoCommand = Get-Command -Name 'Uninstall-ChocolateyPackage' -Module 'Chocolatey'
-                $chocoCommandParams['Force'] = $true
             }
         }
 

--- a/source/Classes/003.ChocolateySoftware.ps1
+++ b/source/Classes/003.ChocolateySoftware.ps1
@@ -179,11 +179,11 @@ class ChocolateySoftware
             if ( -not [string]::isNullOrEmpty($this.InstallationDirectory))
             {
                 Write-Debug -Message ('Uninstall-Chocolatey -InstallationDir ''{0}''' -f $this.InstallationDirectory)
-                $null = Uninstall-Chocolatey -InstallationDir $this.InstallationDirectory
+                $null = Uninstall-Chocolatey -InstallationDir $this.InstallationDirectory -Confirm:$false
             }
             else
             {
-                $null = Uninstall-Chocolatey
+                $null = Uninstall-Chocolatey -Confirm:$false
             }
         }
         else

--- a/source/WikiSource/Home.md
+++ b/source/WikiSource/Home.md
@@ -1,1 +1,3 @@
 # Chocolatey PowerShell module
+
+Welcome to the Chocolatey PowerShell Module wiki!

--- a/source/public/Uninstall-Chocolatey.ps1
+++ b/source/public/Uninstall-Chocolatey.ps1
@@ -21,10 +21,9 @@
 #>
 function Uninstall-Chocolatey
 {
-    [CmdletBinding(
-        SupportsShouldProcess
-    )]
-    param (
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
         [Parameter()]
         [AllowNull()]
         [System.String]
@@ -34,11 +33,10 @@ function Uninstall-Chocolatey
     process
     {
         #If InstallDir is empty or null, select from whee choco.exe is available
-
         if (-not $InstallDir)
         {
-            Write-Debug "Attempting to find the choco.exe command."
-            $chocoCmd = Get-Command 'choco.exe' -CommandType Application -ErrorAction SilentlyContinue
+            Write-Debug -Message "Attempting to find the choco.exe command."
+            $chocoCmd = Get-Command -Name 'choco.exe' -CommandType 'Application' -ErrorAction 'SilentlyContinue'
             #Install dir is where choco.exe is found minus \bin subfolder
             if (-not ($chocoCmd -and ($chocoBin = Split-Path -Parent $chocoCmd.Path -ErrorAction SilentlyContinue)))
             {
@@ -51,18 +49,19 @@ function Uninstall-Chocolatey
                 $InstallDir = (Resolve-Path ([io.path]::combine($chocoBin, '..'))).Path
             }
         }
-        Write-Verbose "Chocolatey Installation Folder is $InstallDir"
 
+        Write-Verbose "Chocolatey Installation Folder is $InstallDir"
         $chocoFiles = @('choco.exe', 'chocolatey.exe', 'cinst.exe', 'cuninst.exe', 'clist.exe', 'cpack.exe', 'cpush.exe',
             'cver.exe', 'cup.exe').Foreach{ $_; "$_.old" } #ensure the .old are also removed
 
         #If Install dir does not have a choco.exe, do nothing as it could delete unwanted files
-        if (
+        if
+        (
             [string]::IsNullOrEmpty($InstallDir) -or
-            -not ((Test-Path $InstallDir) -and (Test-Path "$InstallDir\Choco.exe"))
+            -not ((Test-Path -Path $InstallDir) -and (Test-Path -Path "$InstallDir\Choco.exe"))
         )
         {
-            Write-Warning 'Chocolatey Installation Folder Not found.'
+            Write-Warning -Message 'Chocolatey Installation Folder Not found.'
             return
         }
 
@@ -86,7 +85,7 @@ function Uninstall-Chocolatey
             $FilesToRemove | Sort-Object -Descending FullName | remove-item -Force -recurse -ErrorAction 'SilentlyContinue' -Confirm:$false
         }
 
-        Write-Verbose "Removing $InstallDir from the Path and the ChocolateyInstall Environment variable."
+        Write-Verbose -Message "Removing $InstallDir from the Path and the ChocolateyInstall Environment variable."
         [Environment]::SetEnvironmentVariable('ChocolateyInstall', $null, 'Machine')
         $Env:ChocolateyInstall = $null
         $AllPaths = [Environment]::GetEnvironmentVariable('Path', 'machine').split(';').where{

--- a/tests/kitchen/GCPackages/ChocolateyIsInstalled/ChocolateyIsInstalled.tests.ps1
+++ b/tests/kitchen/GCPackages/ChocolateyIsInstalled/ChocolateyIsInstalled.tests.ps1
@@ -32,17 +32,17 @@ Describe 'Test ChocolateyIsInstalled Package' {
         $result.complianceStatus | Should -be $true
     }
 
-    # it 'Gets the non-compliant InstalledApplicationLinux @(''powershell-preview'',''somethingNotInstalled'') Package Compliance Status (with params)' {
+    it 'Remediates the non-compliant ChocolateyIsInstalled with Putty as param' {
 
-    #     # $result = $null
-    #     # $result = Get-GuestConfigurationPackageComplianceStatus -Path $packageZip -Parameter @{
-    #     #     ResourceType = "GC_InstalledApplicationLinux"
-    #     #     ResourceId = "InstalledApplicationLinux"
-    #     #     ResourcePropertyName =  "AttributesYmlContent"
-    #     #     ResourcePropertyValue = "powershell;somethingNotInstalled"
-    #     # }
+        $result = $null
+        $result = Start-GuestConfigurationPackageRemediation -Path $packageZip -Parameter @{
+            ResourceType = "ChocolateyPackage"
+            ResourceId = "chocoSoftwareInstalled"
+            ResourcePropertyName =  "Name"
+            ResourcePropertyValue = "putty.portable"
+        }
 
-    #     # $result.Resources.Reasons | Should -not -BeNullOrEmpty
-    #     # $result.complianceStatus | Should -be $false
-    # }
+        $result.Resources.Reasons | Should -not -BeNullOrEmpty
+        $result.complianceStatus | Should -be $true
+    }
 }


### PR DESCRIPTION
ChocolateyPackage Resource will now install specific package and it's "dependencies" by default, but uninstalling will only uninstall the package.
To remove the dependency, one should ensure absent AND add choco option @{ForceDependencies = $true}